### PR TITLE
Fixed Django 3.2 deprecation warnings

### DIFF
--- a/wagtaillinkchecker/__init__.py
+++ b/wagtaillinkchecker/__init__.py
@@ -1,6 +1,10 @@
 __version__ = '0.1.0'
 
-default_app_config = 'wagtaillinkchecker.apps.WagtailLinkchekerAppConfig'
+# define default AppConfig - obsolete in Django 3.2 and above
+from django import VERSION
+django_float_version = float(f"{VERSION[0]}.{VERSION[1]}")
+if django_float_version < 3.2:
+      default_app_config = 'wagtaillinkchecker.apps.WagtailLinkchekerAppConfig'
 
 HTTP_STATUS_CODES = {
     100: ('Continue', 'Request received, please continue'),

--- a/wagtaillinkchecker/models.py
+++ b/wagtaillinkchecker/models.py
@@ -2,7 +2,7 @@ from sys import version
 from django.db import models
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtaillinkchecker import utils
 

--- a/wagtaillinkchecker/scanner.py
+++ b/wagtaillinkchecker/scanner.py
@@ -4,7 +4,7 @@ except ImportError:
     import httplib as client
 
 import requests
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtaillinkchecker import HTTP_STATUS_CODES
 
 

--- a/wagtaillinkchecker/tasks.py
+++ b/wagtaillinkchecker/tasks.py
@@ -2,7 +2,7 @@ from celery import shared_task
 from wagtaillinkchecker.scanner import get_url, clean_url
 from wagtaillinkchecker.models import ScanLink
 from bs4 import BeautifulSoup
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django.db.utils import IntegrityError
 from django.utils import timezone

--- a/wagtaillinkchecker/urls.py
+++ b/wagtaillinkchecker/urls.py
@@ -1,18 +1,18 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.conf.urls import url
+from django.urls import path
 
 from wagtaillinkchecker import views
 
 urlpatterns = [
-    url(r'^$', views.index,
+    path('', views.index,
         name='wagtaillinkchecker'),
-    url(r'^settings/$', views.settings,
+    path('settings/', views.settings,
         name='wagtaillinkchecker_settings'),
-    url(r'^scan/$', views.run_scan,
+    path('scan/', views.run_scan,
         name='wagtaillinkchecker_runscan'),
-    url(r'^scan/(?P<scan_pk>\d+)/$', views.scan,
+    path('scan/<int:scan_pk>/', views.scan,
         name='wagtaillinkchecker_scan'),
-    url(r'^scan/(?P<scan_pk>\d+)/delete$', views.delete,
+    path('scan/<int:scan_pk>/delete', views.delete,
         name='wagtaillinkchecker_delete'),
 ]

--- a/wagtaillinkchecker/views.py
+++ b/wagtaillinkchecker/views.py
@@ -8,7 +8,7 @@ try:
 except ModuleNotFoundError:
     from functools import lru_cache
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtaillinkchecker.forms import SitePreferencesForm
 from wagtaillinkchecker.models import SitePreferences, Scan

--- a/wagtaillinkchecker/wagtail_hooks.py
+++ b/wagtaillinkchecker/wagtail_hooks.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 from django import __version__ as DJANGO_VERSION
-from django.conf.urls import include, url
-from django.utils.translation import ugettext_lazy as _
+from django.urls import include, path
+from django.utils.translation import gettext_lazy as _
 
 from wagtaillinkchecker import urls
 from wagtaillinkchecker import utils
@@ -23,7 +23,7 @@ else:
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^link-checker/', include(urls)),
+        path('link-checker/', include(urls)),
     ]
 
 


### PR DESCRIPTION
[Removed default_app_config for Django 3.2 and above (see [3.2 Release Notes](https://docs.djangoproject.com/en/4.0/releases/3.2/#automatic-appconfig-discovery))
Changed url configs from url() to path()
Changed all ugettext imports to gettext